### PR TITLE
feat: update to kconnect 0.5.7 release

### DIFF
--- a/plugins/connect.yaml
+++ b/plugins/connect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: connect
 spec:
-  version: v0.5.6
+  version: v0.5.7
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.6/kconnect_linux_amd64.tar.gz
-    sha256: 2eaf11ad419a47cc89c39ee82dc8202d5cf8a0384e12fbc851c2f3e70fb0a973
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.7/kconnect_linux_amd64.tar.gz
+    sha256: f9392b24c72271bc8f4252efc4f0b645bffaf84fd425ed0c81fd6b43c8564a30
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.6/kconnect_linux_arm64.tar.gz
-    sha256: d3018814378ee6c3bd79df19c06cae0151ca5db9826b6cf0cf9cb509136bbd25
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.7/kconnect_linux_arm64.tar.gz
+    sha256: 8082cac527404fb61d80037ce20e636cb04feacfe840aedc6e073beb380da6ba
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.6/kconnect_macos_amd64.tar.gz
-    sha256: c279e8265e0af5c826be542f81450c6bf5fd74da493904f3ed9f779eb165fa69
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.7/kconnect_macos_amd64.tar.gz
+    sha256: cf1af658ab7d53af2a26be40b6af7241988ac60e6a93c97ad8e109fa3b578fbf
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.6/kconnect_macos_amd64.tar.gz
-    sha256: c279e8265e0af5c826be542f81450c6bf5fd74da493904f3ed9f779eb165fa69
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.7/kconnect_macos_amd64.tar.gz
+    sha256: cf1af658ab7d53af2a26be40b6af7241988ac60e6a93c97ad8e109fa3b578fbf
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.6/kconnect_windows_amd64.zip
-    sha256: c15c7fe6b2ef529590784791a049c17beab09b43c9d6b04f995b3f63a918d514
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.7/kconnect_windows_amd64.zip
+    sha256: e36f477c77dcb3a42c8368486a4fda9de560d051c3ce01691169be8c5f6063e5
     files:
     - from: "kconnect.exe"
       to: "kubectl-connect.exe"


### PR DESCRIPTION
This PR will update the connect.yaml to include the new `kconnect 0.5.7` release.