### PR TITLE
feat: update to kconnect 0.5.9 release

### DIFF
--- a/plugins/connect.yaml
+++ b/plugins/connect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: connect
 spec:
-  version: v0.5.8
+  version: v0.5.9
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.8/kconnect_linux_amd64.tar.gz
-    sha256: 275dd2cf288878a6a1c61ad989a8a1410892a0f4efbbdb42b39492089b805896
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.9/kconnect_linux_amd64.tar.gz
+    sha256: 0b9ee1cf5ffc7ff15302d868f91d32ef715f5e3fcf1d46081612dc7871ab16c0
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.8/kconnect_linux_arm64.tar.gz
-    sha256: 859a966a6321fa943838b58f0eb6b58bd628bd3b8f64ff6d3e46080e9da5892b
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.9/kconnect_linux_arm64.tar.gz
+    sha256: bce66de61d1d3b90b29bf58d6cc3275a2627521409ad3da6f4ab62c80dac6a17
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.8/kconnect_macos_amd64.tar.gz
-    sha256: ee98b517c3e6293b2fdd77f45fd2755e78a3ce23dd6fe04bbe850765e26e84ca
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.9/kconnect_macos_amd64.tar.gz
+    sha256: 0f080ffda9a84c06bc19e75aa5cfe915197007a2444ddfd505923d8ab2cc9a2a
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.8/kconnect_macos_amd64.tar.gz
-    sha256: ee98b517c3e6293b2fdd77f45fd2755e78a3ce23dd6fe04bbe850765e26e84ca
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.9/kconnect_macos_amd64.tar.gz
+    sha256: 0f080ffda9a84c06bc19e75aa5cfe915197007a2444ddfd505923d8ab2cc9a2a
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.8/kconnect_windows_amd64.zip
-    sha256: 78d125d1313538fd0eeae254c4984f1a49f60ba610d6a916c410aeb80f50e5b1
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.9/kconnect_windows_amd64.zip
+    sha256: 16d32c045a72877e7e272e31fc78655313d876ac9d17e8631c0f6864204de256
     files:
     - from: "kconnect.exe"
       to: "kubectl-connect.exe"


### PR DESCRIPTION
This PR will update the connect.yaml to include the new `kconnect 0.5.9` release.