### PR TITLE
feat: update to kconnect 0.5.11 release

### DIFF
--- a/plugins/connect.yaml
+++ b/plugins/connect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: connect
 spec:
-  version: v0.5.10
+  version: v0.5.11
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.10/kconnect_linux_amd64.tar.gz
-    sha256: 6d892f7ebb45f5b04a69d964a912b135643f39f70e76f2183251e165c79a4a5c
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.11/kconnect_linux_amd64.tar.gz
+    sha256: 2ac3b670170d215d0a60ec24fe58288e75e43e43fff83757e7098c7444ac57a9
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.10/kconnect_linux_arm64.tar.gz
-    sha256: 5198989eedf718e64b20223d58b0a262314ebd05a43892c36f44b453748a1cd5
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.11/kconnect_linux_arm64.tar.gz
+    sha256: 531da12ec3086271411fb8b56396dded7d7d00924b1b53d72269b67f07c68fbf
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.10/kconnect_macos_amd64.tar.gz
-    sha256: ac5d4ad9f8216e455b164635a3466d6968e6266ea16f2d7d1f423ad6430d57ce
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.11/kconnect_macos_amd64.tar.gz
+    sha256: 64ccd5b70101bec2b0b3bd0bc082a65a514c0ee2011fd2b16919a88213de0aaf
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.10/kconnect_macos_amd64.tar.gz
-    sha256: ac5d4ad9f8216e455b164635a3466d6968e6266ea16f2d7d1f423ad6430d57ce
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.11/kconnect_macos_amd64.tar.gz
+    sha256: 64ccd5b70101bec2b0b3bd0bc082a65a514c0ee2011fd2b16919a88213de0aaf
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.10/kconnect_windows_amd64.zip
-    sha256: 481a400b396dea901e0ed00f149ecadc4ff31523beb02b849dafb0056a332e8a
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.11/kconnect_windows_amd64.zip
+    sha256: 618f1580fdf4c1e34a4321eefd7b6e13e97ef5c9fd517c94db159ed91a4998e5
     files:
     - from: "kconnect.exe"
       to: "kubectl-connect.exe"


### PR DESCRIPTION
This PR will update the connect.yaml to include the new `kconnect 0.5.11` release.