### PR TITLE
feat: update to kconnect 0.5.19 release

### DIFF
--- a/plugins/connect.yaml
+++ b/plugins/connect.yaml
@@ -3,17 +3,17 @@ kind: Plugin
 metadata:
   name: connect
 spec:
-  version: v0.5.18
+  version: v0.5.19
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
-    kconnect is a tool that can be used to discover and securely access Kubernetes 
+    kconnect is a tool that can be used to discover and securely access Kubernetes
     clusters across multiple operating environments.
-    Based on the authentication mechanism chosen the CLI will discover Kubernetes 
-    clusters you are allowed to access in a target hosting environment (i.e. EKS, AKS, Rancher) 
+    Based on the authentication mechanism chosen the CLI will discover Kubernetes
+    clusters you are allowed to access in a target hosting environment (i.e. EKS, AKS, Rancher)
     and generate a kubeconfig for a chosen cluster.
     Features:
-    - Authenticate using SAML or Azure Active Directory 
+    - Authenticate using SAML or Azure Active Directory
     - Discover EKS, AKS & Rancher clusters
     - Generate a kubeconfig for a cluster
     - Query history of connected servers
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.18/kconnect_linux_amd64.tar.gz
-    sha256: 7134782999af2dd070d190fbac09bd300a2af9229e4b766ae5cc02b429d49120
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.19/kconnect_linux_amd64.tar.gz
+    sha256: 863ada540ddfe24caefa16dfed53142b07a575434272050b0c24930906b5e612
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.18/kconnect_linux_arm64.tar.gz
-    sha256: d552fc5c4c521fdd8161d6fe7138980307f5c8219a2e40bda95f045cd6fa1d92
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.19/kconnect_linux_arm64.tar.gz
+    sha256: 8ddad949e07c6619bd45b77b669c8cd763767ecd1ab28ebaabf4de6aa7f1ce27
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.18/kconnect_macos_amd64.tar.gz
-    sha256: 9e52800b2a710c7ccd595e16e8c824fb7405ec94ceca19146a6d52d7429ebae1
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.19/kconnect_macos_amd64.tar.gz
+    sha256: 9b9b7bb8ccca6aa020bbbafc58fad2a46b04d72bf92d75c0c537a1260fc8ac9e
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.18/kconnect_macos_amd64.tar.gz
-    sha256: 9e52800b2a710c7ccd595e16e8c824fb7405ec94ceca19146a6d52d7429ebae1
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.19/kconnect_macos_amd64.tar.gz
+    sha256: 9b9b7bb8ccca6aa020bbbafc58fad2a46b04d72bf92d75c0c537a1260fc8ac9e
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.18/kconnect_windows_amd64.zip
-    sha256: fafb6c08bb7438441146617d831652d0dca1a8697e9bd42b838807788e8e4012
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.19/kconnect_windows_amd64.zip
+    sha256: 42242a04b38ef6d7d8f1af2ef448d6bf7fd8e38217c740e55c28f262afb20387
     files:
     - from: "kconnect.exe"
       to: "kubectl-connect.exe"


### PR DESCRIPTION
This PR will update the `connect.yaml` to include the new kconnect `0.5.19` release.