### PR TITLE
feat: update to kconnect 0.5.23 release

### DIFF
--- a/plugins/connect.yaml
+++ b/plugins/connect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: connect
 spec:
-  version: v0.5.22
+  version: v0.5.23
   homepage: https://github.com/fidelity/kconnect
   shortDescription: "Discover and access clusters"
   description: |
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.22/kconnect_linux_amd64.tar.gz
-    sha256: 2e3bb23f86867cfea35929c5a86fb46ac8a0c032312eb31cfb85b044ad5403aa
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.23/kconnect_linux_amd64.tar.gz
+    sha256: b39c4773b431aed1dc0577f8a37a1c1eb19e345ab136b64fc691442b53a00155
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.22/kconnect_linux_arm64.tar.gz
-    sha256: 0046af34a1693c2dc612bbd3eee99af370afb6160055ae2bd1847a0bfde770de
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.23/kconnect_linux_arm64.tar.gz
+    sha256: 739fbc09ed9ecfef6f518b8f5e9c10d33ca3012a1af8cd38a8d4a75f7ffa6ab2
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -50,8 +50,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.22/kconnect_macos_amd64.tar.gz
-    sha256: 4487f5ce7760cee494f8b07d0580b6db5b37e03c5adeee22de9b26f62253054c
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.23/kconnect_macos_amd64.tar.gz
+    sha256: defdc41eb0b7e175781046f13479edc52b191ce8dc9175a6260dcdfff2965298
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -62,8 +62,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.22/kconnect_macos_arm64.tar.gz
-    sha256: 04d7bec4ad7fa7d427d2bed9f610104e33937230542bcf70023f8458a26e4d88
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.23/kconnect_macos_arm64.tar.gz
+    sha256: 77710da0b457f24754e97fea57a1d38e95420215b7d7bbc8d8ce30f1d593ff24
     files:
     - from: "kconnect"
       to: "kubectl-connect"
@@ -74,8 +74,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/fidelity/kconnect/releases/download/0.5.22/kconnect_windows_amd64.zip
-    sha256: 41095000d493657f413c874af15ff9e79ef263d496d66cf29d2659c2bf5d9897
+    uri: https://github.com/fidelity/kconnect/releases/download/0.5.23/kconnect_windows_amd64.zip
+    sha256: 55193caf6a696e384ddae178ef70e8509e84a91c5dcea921d141c292a6f82fb7
     files:
     - from: "kconnect.exe"
       to: "kubectl-connect.exe"


### PR DESCRIPTION
This PR will update the `connect.yaml` to include the new kconnect `0.5.23` release.